### PR TITLE
Add LogError to LoggerNOP

### DIFF
--- a/APLSource/Core/LoggerNOP.aplc
+++ b/APLSource/Core/LoggerNOP.aplc
@@ -9,4 +9,8 @@
       :Access Public Instance
     ∇
 
+    ∇ {severity}LogError args
+      :Access Public Instance
+    ∇
+
 :EndClass


### PR DESCRIPTION
The LoggerNOP must also have an implementation of `LogError` method.