### PR TITLE
Add ResourceAttributes to Configuration

### DIFF
--- a/APLSource/Core/Configuration.aplc
+++ b/APLSource/Core/Configuration.aplc
@@ -1,4 +1,5 @@
 :Class Configuration
+    :Include Tools
 ⍝ Configuration of OpenTelemetry SDK
 
     :Field Private Instance _batchSize
@@ -7,6 +8,7 @@
     :Field Private Instance _otelHttpUrlLogs
     :Field Private Instance _otelHttpUrlMetrics
     :Field Private Instance _otelHttpUrlTraces
+    :Field Private Instance _resourceAttributes
     :Field Private Instance _serviceName
     :Field Private Instance _serviceVersion
     :Field Private Instance _debug
@@ -14,7 +16,8 @@
     :Field Private Instance _loggers
     :Field Private Instance _exporters
 
-    ∇ make0
+
+    ∇ make0;resAttr
       :Access Public
       :Implements Constructor
       _batchSize←100
@@ -24,6 +27,9 @@
       _otelHttpUrlLogs←(_otelHttpUrl,'v1/logs')getEnv'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT'
       _otelHttpUrlMetrics←(_otelHttpUrl,'v1/metrics')getEnv'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT'
       _otelHttpUrlTraces←(_otelHttpUrl,'v1/traces')getEnv'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'
+      resAttr←2↑[2]↑'='(≠⊆⊢)¨','(≠⊆⊢)getEnv'OTEL_RESOURCE_ATTRIBUTES'
+      resAttr←'\$\{([^}]*)\}'⎕R{getEnv 2↓¯1↓⍵.Match}¨resAttr
+      _resourceAttributes←checkAttributes resAttr
       _serviceName←getEnv'OTEL_SERVICE_NAME'
       _serviceVersion←getEnv'OTEL_SERVICE_VERSION'
       LogLevel←'info'getEnv'OTEL_LOG_LEVEL'
@@ -124,6 +130,17 @@
         ∇ set ipa
     ⍝TODO: Validate OtelHttpUrlTraces
           _otelHttpUrlTraces←ipa.NewValue
+        ∇
+    :EndProperty
+
+    :Property Simple ResourceAttributes
+    :Access Public
+        ∇ r←get
+          r←_resourceAttributes
+        ∇
+        ∇ set arg;attrm
+          attrm←toKeyValueMatrix arg.NewValue
+          _resourceAttributes←checkAttributes _resourceAttributes⍪attrm
         ∇
     :EndProperty
 

--- a/APLSource/Core/LoggerProvider.aplc
+++ b/APLSource/Core/LoggerProvider.aplc
@@ -34,7 +34,7 @@
           _resourceLog←_logs.⎕NS''
           _logs.resourceLogs←,_resourceLog
           resource←_resourceLog.(resource←⎕NS'')
-          resource.attributes←toKeyValue/2 2⍴'service.name'_cfgServiceName'service.version'_cfgServiceVersion
+          resource.attributes←toKeyValue/cfg.ResourceAttributes⍪2 2⍴'service.name'_cfgServiceName'service.version'_cfgServiceVersion
           _resourceLog.scopeLogs←⍬
           _isShuttingDown←0
           _httpClt←⎕NEW PS.HttpCommand

--- a/APLSource/Core/MeterProvider.aplc
+++ b/APLSource/Core/MeterProvider.aplc
@@ -41,7 +41,7 @@
           _resourceMetric←_metrics.⎕NS''
           _metrics.resourceMetrics←,_resourceMetric
           resource←_resourceMetric.(resource←⎕NS'')
-          resource.attributes←toKeyValue/2 2⍴'service.name'_cfgServiceName'service.version'_cfgServiceVersion
+          resource.attributes←toKeyValue/cfg.ResourceAttributes⍪2 2⍴'service.name'_cfgServiceName'service.version'_cfgServiceVersion
           _resourceMetric.scopeMetrics←⍬
      
           _httpClt←⎕NEW PS.HttpCommand

--- a/APLSource/Core/TracerProvider.aplc
+++ b/APLSource/Core/TracerProvider.aplc
@@ -38,7 +38,7 @@
           _resourceSpan←_traces.⎕NS''
           _traces.resourceSpans←,_resourceSpan
           resource←_resourceSpan.(resource←⎕NS'')
-          resource.attributes←toKeyValue/2 2⍴'service.name'cfg.ServiceName'service.version'cfg.ServiceVersion
+          resource.attributes←toKeyValue/cfg.ResourceAttributes⍪2 2⍴'service.name'_cfgServiceName'service.version'_cfgServiceVersion
           _resourceSpan.scopeSpans←⍬
      
           _httpClt←⎕NEW PS.HttpCommand


### PR DESCRIPTION
Supports setting resource attributes via the environment variable `OTEL_RESOURCE_ATTRIBUTES` and explicitly via configuration property `ResourceAttributes`.