### PR TITLE
Expose function SetActiveSpan

### DIFF
--- a/APLSource/Core/ITracer.apli
+++ b/APLSource/Core/ITracer.apli
@@ -5,6 +5,9 @@
     ∇ r←GetActiveSpan
     ∇
 
+    ∇ {r}←SetActiveSpan span
+    ∇
+
     ∇ span←{context}StartSpan name
     ∇
 

--- a/APLSource/Core/ITracerProvider.apli
+++ b/APLSource/Core/ITracerProvider.apli
@@ -15,6 +15,9 @@
     ∇ span←GetActiveSpan
     ∇
 
+    ∇ r←SetActiveSpan span
+    ∇
+
     ∇ span←{context}StartSpan args
     ∇
 

--- a/APLSource/Core/Span.aplc
+++ b/APLSource/Core/Span.aplc
@@ -20,7 +20,7 @@
    ⍝ contains an Event name and Event attribute.
 
     :Field Private Instance links←⍬
-    :Field Private Instance isEnded←0
+    :Field Public Instance isEnded←0
     :Field Private Instance scopeSpan←⍬
 
     :Field Private Shared PS←##

--- a/APLSource/Core/Span.aplc
+++ b/APLSource/Core/Span.aplc
@@ -20,7 +20,7 @@
    ⍝ contains an Event name and Event attribute.
 
     :Field Private Instance links←⍬
-    :Field Public Instance isEnded←0
+    :Field Private Instance _isEnded←0
     :Field Private Instance scopeSpan←⍬
 
     :Field Private Shared PS←##
@@ -28,8 +28,8 @@
     ∇ make args
       :Access Public
       :Implements Constructor
-      isEnded←0=≢⊃args
-      →isEnded/0
+      _isEnded←0=≢⊃args
+      →_isEnded/0
       (scopeSpan traceId _parentSpanId spanId name _cfgDebug _cfgLogLevel _cfgLoggers)←args
       _startTime←timeUnixNano 0
       ⍝
@@ -41,7 +41,7 @@
           r←_kind
         ∇
         ∇ set ipa
-          →isEnded/0
+          →_isEnded/0
           :Trap _cfgDebug↓0
               :If (⊂ipa.NewValue)∊PS.API.SpanKind.(UNSPECIFIED INTERNAL SERVER CLIENT PRODUCER CONSUMER)
                   _kind←ipa.NewValue
@@ -60,7 +60,7 @@
           r←_statusCode
         ∇
         ∇ set ipa
-          →isEnded/0
+          →_isEnded/0
           :Trap _cfgDebug↓0
               :If (⊂ipa.NewValue)∊PS.API.SpanStatusCode.(OK ERROR)
                   _statusCode←ipa.NewValue
@@ -79,7 +79,7 @@
           r←_statusMessage
         ∇
         ∇ set ipa
-          →isEnded/0
+          →_isEnded/0
           :Trap _cfgDebug↓0
               :If 0=10|⎕DR ipa.NewValue
               :AndIf 1=≡ipa.NewValue
@@ -90,6 +90,13 @@
           :Else
               logError
           :EndTrap
+        ∇
+    :EndProperty
+
+    :Property Simple isEnded
+    :Access Public
+        ∇ r←get
+          r←_isEnded
         ∇
     :EndProperty
 
@@ -182,10 +189,10 @@
     ∇ End;r
       :Access Public
      ⍝ Marks the end of Span execution.
-      →isEnded/0
+      →_isEnded/0
       :Trap _cfgDebug↓0
           _endTime←timeUnixNano 0
-          isEnded←1
+          _isEnded←1
      
           r←scopeSpan.⎕NS''
           r.name←name

--- a/APLSource/Core/Tracer.aplc
+++ b/APLSource/Core/Tracer.aplc
@@ -21,6 +21,17 @@
       r←##.GetActiveSpan
     ∇
 
+    ∇ {r}←SetActiveSpan span
+      :Implements Method ITracer.SetActiveSpan
+      ⍝ Set span as active.
+      ⍝ r: return code (0=success,1=failure)
+      :If span.isEnded
+        r←1
+      :Else
+        r←##.SetActiveSpan span
+      :EndIF
+    ∇
+
     ∇ span←{context}StartSpan name
       :Implements Method ITracer.StartSpan
      ⍝ Create span with name in context.

--- a/APLSource/Core/Tracer.aplc
+++ b/APLSource/Core/Tracer.aplc
@@ -29,7 +29,7 @@
         r←1
       :Else
         r←##.SetActiveSpan span
-      :EndIF
+      :EndIf
     ∇
 
     ∇ span←{context}StartSpan name

--- a/APLSource/Core/TracerNOP.aplc
+++ b/APLSource/Core/TracerNOP.aplc
@@ -2,7 +2,7 @@
 
     ∇ make
       :Access Public
-      :Implements Constructor 
+      :Implements Constructor
     ∇
 
     ∇ r←GetContext
@@ -13,6 +13,11 @@
     ∇ r←GetActiveSpan
       :Implements Method ITracer.GetActiveSpan
       r←⍬
+    ∇
+
+    ∇ {r}←SetActiveSpan span
+      :Implements Method ITracer.SetActiveSpan
+      r←0
     ∇
 
     ∇ span←{context}StartSpan name
@@ -26,4 +31,3 @@
     ∇
 
 :EndClass
-

--- a/APLSource/Core/TracerProvider.aplc
+++ b/APLSource/Core/TracerProvider.aplc
@@ -100,6 +100,19 @@
       :EndTrap
     ∇
 
+    ∇ r←SetActiveSpan span
+      :Implements Method ITracerProvider.SetActiveSpan
+     ⍝ Sets the span as active.
+      :Trap _cfgDebug↓0
+          PS.SetActiveSpan span
+          r←0
+      :Else
+          logError
+          r←1
+      :EndTrap
+    ∇
+
+
     ∇ span←{context}StartSpan args;parent;ind;traceId;parentId;spanId;name;create;scopeSpan
       :Implements Method ITracerProvider.StartSpan
      ⍝ Start span without setting it on context.

--- a/APLSource/Core/TracerProviderNOP.aplc
+++ b/APLSource/Core/TracerProviderNOP.aplc
@@ -31,6 +31,11 @@
       r←⍬
     ∇
 
+     ∇ r←SetActiveSpan span
+      :Implements Method ITracerProvider.SetActiveSpan
+      r←0
+    ∇
+
     ∇ r←{context}StartSpan args
       :Implements Method ITracerProvider.StartSpan
       r←⎕NEW PS.Span(⍬'' '' '' '' 0 0 ⍬)

--- a/APLSource/Tests/Span/TestSetActiveSpan.aplf
+++ b/APLSource/Tests/Span/TestSetActiveSpan.aplf
@@ -1,0 +1,22 @@
+ TestSetActiveSpan;cfg;tracer;span1;span2;span3;activeSpan
+ ##.Reset
+ cfg←##.Notela.NewConfiguration'TestTraces'
+ cfg.WithExporter'##.TokenExporter'
+ cfg.BatchSize←3
+ ##.Notela.Start cfg
+ tracer←##.Notela.GetTracer'TestTraces'
+ span1←tracer.StartSpan'span1'
+ span2←tracer.StartSpan'span2'
+ tracer.SetActiveSpan span1
+ span3←tracer.StartSpan'span3'
+ activeSpan←tracer.GetActiveSpan
+
+ Assert activeSpan≡span1
+ Assert activeSpan.traceId≡span3.traceId
+ Assert activeSpan.traceId≢span2.traceId
+
+ span1.End
+ span2.End
+ span3.End
+
+ Assert 1=tracer.SetActiveSpan span1


### PR DESCRIPTION
Expose the function SetActiveSpan to user, to be able to set an inactive span instance as active.

Closes #40